### PR TITLE
Push notification payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canaritus",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "A status page with native push notifications to subscribers",
   "main": "src/server/server.js",
   "scripts": {
@@ -60,6 +60,7 @@
     "redux-thunk": "1.0.0",
     "serve-static": "^1.10.0",
     "sqlite3": "^3.1.0",
+    "web-push-encryption": "github:googlechrome/push-encryption-node",
     "webpack": "1.12.2"
   }
 }

--- a/server.js
+++ b/server.js
@@ -54,7 +54,6 @@ if (config.uptime_checks.native.enabled) {
  * Api endpoints
  */
 app.get('/api/status', api.getStatus);
-app.get('/api/status/:host', api.getHostStatus);
 app.post('/api/subscribe', api.subscribe);
 app.post('/api/unsubscribe', api.unsubscribe);
 app.get('/api/event', api.getEvent);

--- a/server.js
+++ b/server.js
@@ -21,7 +21,7 @@ app.set('view engine', 'jade');
  * Initialize Database
  */
 const db = new Database('canaritus.db');
-db.run('CREATE TABLE IF NOT EXISTS ids (id TEXT, UNIQUE(id))');
+db.run('CREATE TABLE IF NOT EXISTS subscriptions (endpoint TEXT, p256dh TEXT, auth TEXT, UNIQUE(endpoint))');
 db.run('CREATE TABLE IF NOT EXISTS events (host TEXT, type TEXT, healthy BOOLEAN, title TEXT, body TEXT, time DATETIME)');
 db.close();
 

--- a/src/client/utils.js
+++ b/src/client/utils.js
@@ -1,7 +1,6 @@
 export const sendSubscriptionChange = (subscription, type) => {
   // TODO: Dispatch this as an action
-  const {endpoint} = subscription;
-  const id = endpoint.split('/')[endpoint.split('/').length - 1];
+
   fetch('/api/' + type, {
     method: 'post',
     headers: {

--- a/src/client/utils.js
+++ b/src/client/utils.js
@@ -8,8 +8,6 @@ export const sendSubscriptionChange = (subscription, type) => {
       'Accept': 'application/json',
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({
-      id: id,
-    }),
+    body: JSON.stringify(subscription),
   });
 };

--- a/src/server/api/http.js
+++ b/src/server/api/http.js
@@ -32,15 +32,17 @@ export const getHostStatus = (req, res) => {
 
 export const subscribe = (req, res) => {
   const db = new Database('canaritus.db');
-  const id = req.body.id;
-  if (!id) {
-    res.status(400).send('id is missing from the post');
+  const {endpoint, keys} = req.body;
+  if (!endpoint) {
+    res.status(421).send('id is missing from the post');
+  } else if (!keys || !keys.p256dh || !keys.auth) {
+    res.status(421).send('keys are missing fromt he post');
   } else {
-    log('DB', `Adding ${id} to ids table`);
+    log('DB', `Adding ${endpoint} to subscriptions table`);
     db.serialize(() => {
-      db.run(`INSERT OR IGNORE INTO ids (id) VALUES('${id}')`, (err) => {
+      db.run(`INSERT OR IGNORE INTO subscriptions (endpoint, p256dh, auth) VALUES('${endpoint}', '${keys.p256dh}', '${keys.auth}')`, (err) => {
         if (err !== null) {
-          log('DB', 'Error adding id', err);
+          log('DB', 'Error adding subscription', err);
           res.sendStatus(500);
         } else {
           res.sendStatus(201);

--- a/src/server/api/http.js
+++ b/src/server/api/http.js
@@ -12,24 +12,6 @@ export const getStatus = (req, res) => {
   res.json(hosts);
 };
 
-export const getHostStatus = (req, res) => {
-  const db = new Database('canaritus.db');
-  const host = req.params.host;
-
-  db.serialize(() => {
-    db.all(`SELECT * FROM events WHERE host='${host}'`, (err, events) => {
-      if (err) {
-        res.status(500).send('Unable to get events');
-      } else if (events.length === 0) {
-        res.sendStatus(404);
-      } else {
-        res.status(200).json(events);
-      }
-    });
-  });
-  db.close();
-};
-
 export const subscribe = (req, res) => {
   const db = new Database('canaritus.db');
   const {endpoint, keys} = req.body;
@@ -55,13 +37,13 @@ export const subscribe = (req, res) => {
 
 export const unsubscribe = (req, res) => {
   const db = new Database('canaritus.db');
-  const id = req.body.id;
-  if (!id) {
-    res.status(400).send('id is missing from the post');
+  const {endpoint} = req.body;
+  if (!endpoint) {
+    res.status(421).send('endpoint is missing from the post');
   } else {
-    log('DB', `Removing ${id} from ids table`);
+    log('DB', `Removing ${endpoint} from subscriptions table`);
     db.serialize(() => {
-      db.run(`DELETE FROM ids WHERE id='${id}'`, (err) => {
+      db.run(`DELETE FROM subscriptions WHERE endpoint='${endpoint}'`, (err) => {
         if (err !== null) {
           log('DB', 'Error removing id', err);
           res.sendStatus(500);

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -9,6 +9,8 @@ import {Provider} from 'react-redux';
 import rootReducer from '../client/reducers';
 import CanaritusAppContainer from '../client/containers/CanaritusAppContainer';
 
+import {addAuthToken} from 'web-push-encryption';
+
 const config = load(path.join(__dirname, '..', '..', 'config.yaml'));
 
 export const handleRender = (req, res) => {
@@ -36,3 +38,8 @@ export const manifest = (req, res) => {
     'gcm_sender_id': config.notifications.gcm.project_number,
   });
 };
+
+// Register the gcm authentication key if gcm is enabled
+if (config.notifications.gcm.enabled) {
+  addAuthToken('https://android.googleapis.com/gcm', config.notifications.gcm.auth_token);
+}

--- a/src/server/events.js
+++ b/src/server/events.js
@@ -6,10 +6,10 @@ import {gcmNotification, developmentNotification} from './notifications';
 
 const config = loadYaml(path.join(__dirname, '..', '..', 'config.yaml'));
 
-const pingClients = (title, body) => {
+const pingClients = (title, body, healthy) => {
   const {gcm, development} = config.notifications;
   if (gcm.enabled) {
-    gcmNotification(config);
+    gcmNotification(config, title, body, healthy);
   }
   if (development.enabled) {
     developmentNotification(title, body);
@@ -29,7 +29,7 @@ export const addEvent = (host, type, healthy, title, body) => {
         log('EVENT', 'Error adding event: ' + err);
         return false;
       }
-      pingClients(title, body);
+      pingClients(title, body, healthy);
       return true;
     });
   });

--- a/src/server/notifications/gcm.js
+++ b/src/server/notifications/gcm.js
@@ -1,30 +1,43 @@
 import fetch from 'node-fetch';
 import {log} from '../utils';
 import {Database} from 'sqlite3';
+import {sendWebPush} from 'web-push-encryption';
 
-const gcmNotification = (config) => {
+const plusIcon = '/images/CanaryStatus_plus_256px.png';
+const minusIcon = '/images/CanaryStatus_minus_256px.png';
+
+const generateSubscription = (row) => {
+  return {
+    endpoint: row.endpoint,
+    keys: {
+      p256dh: row.p256dh,
+      auth: row.auth,
+    }
+  }
+}
+
+const gcmNotification = (config, title, body, healthy) => {
+  const message = JSON.stringify({
+    title: title,
+    body: body,
+    tag: 'canaritus-notification-tag-' + healthy ? 'healthy' : 'unhealthy',
+    icon: healthy ? plusIcon : minusIcon,
+  });
   const db = new Database('canaritus.db');
+
   log('PUSH', 'Pinging all clients');
   db.serialize(() => {
-    db.all('SELECT * FROM ids', (err, rows) => {
+    db.all('SELECT * FROM subscriptions', (err, rows) => {
       if (err !== null) {
         log('PUSH', 'Failed to select registration ids');
       } else {
-        const ids = rows.map(x => x.id);
-        log('PUSH', 'Pushing to following ids: ' + ids.map(x => x.substring(0, 10) + '...'));
-        fetch(config.notifications.gcm.endpoint, {
-          method: 'post',
-          headers: {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json',
-            'Authorization': `key=${config.notifications.gcm.server_key}`,
-          },
-          body: JSON.stringify({
-            'registration_ids': ids,
-          }),
-        }).then((res) => {
-          log('PUSH', 'Notification pings sent, status: ' + res.status);
-        });
+        const subscriptions = rows.map(x => generateSubscription(x));
+        log('PUSH', `Pushing to ${subscriptions.length} subscriptions`);
+        for (const sub of subscriptions) {
+          sendWebPush(message, sub).then((res) => {
+            log('PUSH', 'Notification ping sent, status: ' + res.status);
+          });
+        }
       }
     });
   });

--- a/src/server/notifications/gcm.js
+++ b/src/server/notifications/gcm.js
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 import {log} from '../utils';
 import {Database} from 'sqlite3';
 import {sendWebPush} from 'web-push-encryption';
@@ -12,9 +11,9 @@ const generateSubscription = (row) => {
     keys: {
       p256dh: row.p256dh,
       auth: row.auth,
-    }
-  }
-}
+    },
+  };
+};
 
 const gcmNotification = (config, title, body, healthy) => {
   const message = JSON.stringify({
@@ -33,10 +32,13 @@ const gcmNotification = (config, title, body, healthy) => {
       } else {
         const subscriptions = rows.map(x => generateSubscription(x));
         log('PUSH', `Pushing to ${subscriptions.length} subscriptions`);
+
+        const handlePushResult = (res) => {
+          log('PUSH', 'Notification ping sent, status: ' + res.status);
+        };
+
         for (const sub of subscriptions) {
-          sendWebPush(message, sub).then((res) => {
-            log('PUSH', 'Notification ping sent, status: ' + res.status);
-          });
+          sendWebPush(message, sub).then(handlePushResult);
         }
       }
     });

--- a/src/server/utils.js
+++ b/src/server/utils.js
@@ -10,8 +10,12 @@ const timeStamp = () => {
   return `${date} ${time}`;
 };
 
-export const log = (type, string) => {
-  console.log(`${timeStamp()} - ${type} - ${string}`);
+export const log = (type, string, extra = null) => {
+  let out = `${timeStamp()} - ${type} - ${string}`;
+  if (extra) {
+    out += ` - ${extra}`;
+  }
+  console.log(out);
 };
 
 export const timeDuration = (ms) => {

--- a/src/worker/service-worker.js
+++ b/src/worker/service-worker.js
@@ -1,24 +1,18 @@
 /* eslint-env serviceworker */
 self.addEventListener('push', (event) => {
-  const plusIcon = '/images/CanaryStatus_plus_256px.png';
-  const minusIcon = '/images/CanaryStatus_minus_256px.png';
-
   if (event.data) {
     const {title} = event.data.json();
     return self.registration.showNotification(title, event.data.json());
-  } else {
-    console.error('Unable to retrieve data', err);
-
-    const title = 'An error occurred';
-    const body = 'We were unable to get the information for this push message';
-    const tag = 'notification-error';
-
-    return self.registration.showNotification(title, {
-      body: body,
-      icon: minusIcon,
-      tag: tag,
-    });
   }
+  const title = 'An error occurred';
+  const body = 'We were unable to get the information for this push message';
+  const tag = 'notification-error';
+
+  return self.registration.showNotification(title, {
+    body: body,
+    icon: '/images/CanaryStatus_minus_256px.png',
+    tag: tag,
+  });
 });
 
 self.addEventListener('notificationclick', (event) => {

--- a/src/worker/service-worker.js
+++ b/src/worker/service-worker.js
@@ -2,38 +2,43 @@
 self.addEventListener('push', (event) => {
   const plusIcon = '/images/CanaryStatus_plus_256px.png';
   const minusIcon = '/images/CanaryStatus_minus_256px.png';
-  event.waitUntil(fetch('/api/event').then((res) => {
-    if (res.status !== 200) {
-      console.log('Error fetching latest notification:', res.status);
-      throw new Error();
-    }
+  if (event.data) {
+    // Payload bitches!
+    console.log(event.data.json());
+  } else {
+    event.waitUntil(fetch('/api/event').then((res) => {
+      if (res.status !== 200) {
+        console.log('Error fetching latest notification:', res.status);
+        throw new Error();
+      }
 
-    return res.json().then((data) => {
-      const healthy = data.healthy === 'true';
-      const title = data.title;
-      const body = data.body;
-      const tag = 'canaritus-notification-tag-' + (healthy ? 'healthy' : 'unhealthy');
-      console.log(tag);
+      return res.json().then((data) => {
+        const healthy = data.healthy === 'true';
+        const title = data.title;
+        const body = data.body;
+        const tag = 'canaritus-notification-tag-' + (healthy ? 'healthy' : 'unhealthy');
+        console.log(tag);
+
+        return self.registration.showNotification(title, {
+          body: body,
+          icon: healthy ? plusIcon : minusIcon,
+          tag: tag,
+        });
+      });
+    }).catch((err) => {
+      console.error('Unable to retrieve data', err);
+
+      const title = 'An error occurred';
+      const body = 'We were unable to get the information for this push message';
+      const tag = 'notification-error';
 
       return self.registration.showNotification(title, {
         body: body,
-        icon: healthy ? plusIcon : minusIcon,
+        icon: minusIcon,
         tag: tag,
       });
-    });
-  }).catch((err) => {
-    console.error('Unable to retrieve data', err);
-
-    const title = 'An error occurred';
-    const body = 'We were unable to get the information for this push message';
-    const tag = 'notification-error';
-
-    return self.registration.showNotification(title, {
-      body: body,
-      icon: minusIcon,
-      tag: tag,
-    });
-  }));
+    }));
+  }
 });
 
 self.addEventListener('notificationclick', (event) => {

--- a/src/worker/service-worker.js
+++ b/src/worker/service-worker.js
@@ -2,42 +2,22 @@
 self.addEventListener('push', (event) => {
   const plusIcon = '/images/CanaryStatus_plus_256px.png';
   const minusIcon = '/images/CanaryStatus_minus_256px.png';
+
   if (event.data) {
-    // Payload bitches!
-    console.log(event.data.json());
+    const {title} = event.data.json();
+    return self.registration.showNotification(title, event.data.json());
   } else {
-    event.waitUntil(fetch('/api/event').then((res) => {
-      if (res.status !== 200) {
-        console.log('Error fetching latest notification:', res.status);
-        throw new Error();
-      }
+    console.error('Unable to retrieve data', err);
 
-      return res.json().then((data) => {
-        const healthy = data.healthy === 'true';
-        const title = data.title;
-        const body = data.body;
-        const tag = 'canaritus-notification-tag-' + (healthy ? 'healthy' : 'unhealthy');
-        console.log(tag);
+    const title = 'An error occurred';
+    const body = 'We were unable to get the information for this push message';
+    const tag = 'notification-error';
 
-        return self.registration.showNotification(title, {
-          body: body,
-          icon: healthy ? plusIcon : minusIcon,
-          tag: tag,
-        });
-      });
-    }).catch((err) => {
-      console.error('Unable to retrieve data', err);
-
-      const title = 'An error occurred';
-      const body = 'We were unable to get the information for this push message';
-      const tag = 'notification-error';
-
-      return self.registration.showNotification(title, {
-        body: body,
-        icon: minusIcon,
-        tag: tag,
-      });
-    }));
+    return self.registration.showNotification(title, {
+      body: body,
+      icon: minusIcon,
+      tag: tag,
+    });
   }
 });
 


### PR DESCRIPTION
## Description

Support [Chrome v50+ push notifications with payload](https://developers.google.com/web/updates/2016/03/web-push-encryption).

Uses [GoogleChrome/push-encryption-node](https://github.com/GoogleChrome/push-encryption-node) to encrypt and push the notifications to the client.
## Changes
- DB: Dropped ids table in favour of a subcriptions table to store endpoint and keys
- Web Client: Sends whole subscription to the server, including endpoint and keys
- Server: Construct payload with title, body, notification tag and icon for the push notification, instead of doing it in the service worker
- Bug fix: The debug logging function wasn't accepting extra stuff to log out (such as errors)
