### PR TITLE
Update config example

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -18,9 +18,8 @@ default:
   notifications:
     gcm:
       enabled: true
-      server_key: '<gcm_server_key>'
+      auth_token: '<gcm_server_key>'
       project_number: '<gcm_project_numer>'
-      endpoint: 'https://android.googleapis.com/gcm/send'
     pushover: # Not yet supported
       enabled: false
     pushbuller: # Not yet spported


### PR DESCRIPTION
Forgot to update the config example after renaming the `server_key` to `auth_token`. Not really sure why I even did that renaming.
